### PR TITLE
Remove whitespace

### DIFF
--- a/oscfg/manjaro.sh
+++ b/oscfg/manjaro.sh
@@ -81,7 +81,7 @@ action/lock_screen=false
 logout=false
 action/start_new_session=false
 action/switch_user=false
-EOF		
+EOF
 			;;
 		manjaro-gnome-desktop)
 			run pacman -S --noconfirm adwaita-icon-theme adwaita-maia alacarte baobab file-roller gedit gdm gnome-backgrounds gnome-calculator gnome-control-center gnome-desktop gnome-disk-utility gnome-keyring gnome-online-accounts gnome-initial-setup gnome-screenshot gnome-session gnome-settings-daemon gnome-shell gnome-shell-extensions gnome-shell-extension-nightthemeswitcher gnome-system-log gnome-system-monitor gnome-terminal gnome-themes-standard gnome-tweak-tool gnome-user-docs gnome-wallpapers gnome-clocks gnome-todo gtksourceview-pkgbuild mutter nautilus nautilus-admin nautilus-empty-file seahorse papirus-maia-icon-theme lighter-gnome disable-tracker


### PR DESCRIPTION
This whitespace breaks building gnome profile and thus needs to be removed.