### PR TITLE
base: ingnore 4 cores during xz compression

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -131,7 +131,7 @@ EOF
 		# grab rbdconv
 		git clone https://github.com/Shells-com/rbdconv.git
 	fi
-	php rbdconv/raw-to-rbd.php "$1-$DATE.raw" | xz -z -9 -T $(nproc --ignore=2) -v >"$1-$DATE.shells"
+	php rbdconv/raw-to-rbd.php "$1-$DATE.raw" | xz -z -9 -T $(nproc --ignore=4) -v >"$1-$DATE.shells"
 	rm -f "$1-$DATE.raw"
 
 	# complete, list the file


### PR DESCRIPTION
- on regular PCs it seems you need at least 4 cores/threads ignored to not kill the process