### PR TITLE
base: Fix path to systemd services

### DIFF
--- a/scripts/base.sh
+++ b/scripts/base.sh
@@ -149,9 +149,9 @@ add_firstrun() {
 		AFTER="systemd-networkd-wait-online.service"
 	fi
 
-	if [ -d "$WORK/lib/systemd/system" ]; then
+	if [ -d "$WORK/usr/lib/systemd/system" ]; then
 		# systemd method
-		cat >"$WORK/lib/systemd/system/cloud-firstrun.service" <<EOF
+		cat >"$WORK/usr/lib/systemd/system/cloud-firstrun.service" <<EOF
 [Unit]
 Description=Cloud firstrun handler
 ConditionFileIsExecutable=/.firstrun.sh


### PR DESCRIPTION
The location of the systemd services is, by definition, in /usr/lib/systemd/system.
$WORK/lib/systemd/system can accidentally work on some Distros that have a
/lib -> usr/lib symlink, but it's better to not rely on such things.