### PR TITLE
[manjaro] make sure databases are up to date after mirror ranking

### DIFF
--- a/oscfg/manjaro.sh
+++ b/oscfg/manjaro.sh
@@ -18,7 +18,7 @@ manjaro_cfg() {
 	run pacman -Syu --noconfirm
 	run pacman-mirrors -f 15
 
-	run pacman -S --noconfirm base systemd-sysvcompat iputils inetutils iproute2 sudo qemu-guest-agent
+	run pacman -Syy --noconfirm base systemd-sysvcompat iputils inetutils iproute2 sudo qemu-guest-agent
 
 	# make sudo available without password (default for key auth)
 	echo "%shellsuser ALL=(ALL) NOPASSWD: ALL" > "$WORK/etc/sudoers.d/01-shells" & chmod 440 "$WORK/etc/sudoers.d/01-shells"


### PR DESCRIPTION
After a mirror ranking, the databases needs to be fully updated, else you get the issue with some packages no longer existing.

So update the database on first pacman install command.