### PR TITLE
openSUSE: add shells-helper, make KDE not lock when resuming from sleep

### DIFF
--- a/oscfg/opensuse.sh
+++ b/oscfg/opensuse.sh
@@ -192,6 +192,7 @@ EOF
 		cat >"$WORK/etc/skel/.config/kscreenlockerrc" <<EOF
 [Daemon]
 Autolock=false
+LockOnResume=false
 EOF
 
 cat >"$WORK/etc/skel/.config/kdesurc" <<EOF
@@ -199,6 +200,15 @@ cat >"$WORK/etc/skel/.config/kdesurc" <<EOF
 super-user-command=sudo
 EOF
 
+	fi
+
+	# add shells-helper to /etc/skel
+	if [ ! -f "$WORK/etc/skel/.bin/shells-helper" ]; then
+		mkdir -p "$WORK/etc/skel/.bin"
+		local O="~"
+		cd "$WORK/etc/skel/.bin"
+		curl -s https://raw.githubusercontent.com/KarpelesLab/make-go/master/get.sh | /bin/sh -s shells-helper
+		cd "$O"
 	fi
 
 	# add firstrun


### PR DESCRIPTION
I know the `LockOnResume` fix works, tested it myself. Cloned the shells-helper code from the Ubuntu script, tested and it seems to work.

We do have one issue remaining though, with this PR applied the `sleep` button on the start menu breaks the gui in a bad way until you resize your screen. This PR doesn't currently fix that, and gerpping through https://develop.kde.org/deploy/kiosk/keys/ didn't give me any keys which indicated a way to do so.