### PR TITLE
Hopefully fix KDE neon

### DIFF
--- a/oscfg/ubuntu.sh
+++ b/oscfg/ubuntu.sh
@@ -67,6 +67,7 @@ ubuntu_cfg() {
 			DEBIAN_FRONTEND=noninteractive run apt-get install -y neon-settings
 			DEBIAN_FRONTEND=noninteractive run apt-get full-upgrade -y
 			DEBIAN_FRONTEND=noninteractive run apt-get install -y neon-desktop
+			run pkcon update -y
 			mkdir -p "$WORK/etc/skel/.config"
 			cat >> "$WORK/etc/skel/.config/kdeglobals" <<EOF
 [KDE Action Restrictions]
@@ -79,6 +80,7 @@ EOF
 			cat >"$WORK/etc/skel/.config/kscreenlockerrc" <<EOF
 [Daemon]
 Autolock=false
+LockOnResume=false
 EOF
 
 			;;


### PR DESCRIPTION
This does two things:

- Incorporates the same KDE fix as in #57 (KDE neon seems to not need sleeping to be disabled, it seems to act nicely if you do try to sleep with the tiny fix in this PR).
- Tries to update using `sudo pkcon update -y`

Regarding the updates, if you boot into a neon KDE shell and try to use `sudo apt-get update`, it fails and tells you to instead run `pkcon update`, and so we're missing like a hundred package updates. I'm not sure if this is the right place to call pkcon update, but unfortunately I can't test this out with `./test-linux.sh` before pushing this PR since I've got a mac machine here.